### PR TITLE
Feature/notification text fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,4 +67,4 @@ workflows:
           filters:
             branches:
               only:
-                  - feature/notification_text_fix
+                  - master


### PR DESCRIPTION
Slight update to fix the notification on Mattermost. Now uses same format as other services.
Push from this feature branch showed correctly on Mattermost as: "pillar-bcx-pubsub:529"