### PR TITLE
ethServices mocks / unit tests

### DIFF
--- a/src/__mocks__/abi-decoder.js
+++ b/src/__mocks__/abi-decoder.js
@@ -4,6 +4,6 @@ function addABI() {
 module.exports.addABI = addABI;
 
 function decodeMethod() {
-  return ('smart contract call input data');
+  return {name:"transfer", params: [{value:"0xAddress"}, {value:"1"}]};
 }
 module.exports.decodeMethod = decodeMethod;

--- a/src/__mocks__/web3.js
+++ b/src/__mocks__/web3.js
@@ -950,8 +950,6 @@ const tokenTransfer = {
   s: '0x65a02305bdc1f57563cf14a44983db03c2c3e7a8381a8355da11e5972604f8f4',
 };
 
-
-
 const txReceipt = {
   blockHash: '0x1182ce9f5e30c963bd876a2373ece2c5c60711c626a7e3574c4c511dac05d6bd',
   blockNumber: 2461146,

--- a/src/services/ethService.js
+++ b/src/services/ethService.js
@@ -428,7 +428,7 @@ function checkPendingTx(pendingTxArray) {
                             } else {
                                 abiDecoder.addABI(ERC20ABI);
                             }
-                            data = abiDecoder.decodeMethod(item.input);
+                            const data = abiDecoder.decodeMethod(item.input);
                             if ((data !== undefined) && (data.name === 'transfer')) { 
                                 //smart contract call hence the asset must be the token name
                                 to = data.params[0].value;
@@ -598,7 +598,6 @@ module.exports.getAllTransactionsForWallet = getAllTransactionsForWallet;
 async function getTxInfo(txHash) {
 
     const [txInfo, txReceipt] = await Promise.all([web3.eth.getTransaction(txHash), web3.eth.getTransactionReceipt(txHash)])
-
     var to, value, asset, contractAddress;
     if(!hashMaps.assets.has(txInfo.to.toLowerCase())) { 
         to = txInfo.to;
@@ -612,7 +611,7 @@ async function getTxInfo(txHash) {
         } else {
             abiDecoder.addABI(ERC20ABI);
         }
-        data = abiDecoder.decodeMethod(txInfo.input);
+        const data = abiDecoder.decodeMethod(txInfo.input);
         if ((data !== undefined) && (data.name === 'transfer')) { 
             //smart contract call hence the asset must be the token name
             to = data.params[0].value;

--- a/src/services/ethService.test.js
+++ b/src/services/ethService.test.js
@@ -222,3 +222,13 @@ describe('The getAllTransactionsForWallet function tests', () => {
     done()
   });
 });
+
+describe('The getTxInfo function tests', () => {
+  test('should return the txObject with the same hash', done => {
+    const ethService = require('./ethService');
+    ethService.getTxInfo(Web3.txHash).then(txObject => {
+      expect(txObject.txHash).toBe(Web3.txHash);
+      done();
+    });
+  });
+});

--- a/src/utils/__mocks__/hashMaps.js
+++ b/src/utils/__mocks__/hashMaps.js
@@ -2,12 +2,13 @@ exports.assets = {
 	values: () => {
 		return ['asset1', 'asset2', 'asset3'];
 	},
+	get: (address) => {
+		return {contractAddress: "0x33e9dd7bf74433d25fedc4e9465b08f63360c413da5bc53d6493e325e7ef3c7b", symbol: "ETH"}
+	}
 }
 
 exports.accounts = {
 		has: (address) => {
-			console.log('HASHMAPS ADDRESS')
-			console.log(address)
 			if (address === '0x81b7E08F65Bdf5648606c89998A9CC8164397647'.toLowerCase()) {
 				return true;
 			} else {


### PR DESCRIPTION
adding mock responses to abi-decoder, web3, and hashMaps.
adding 'The getTxInfo function tests' to ethServices tests.
declaring 'data' on ethServices