### PR TITLE
Fix/release announcement qa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ jobs:
           name: Publish Package to Artifactory
           command: |
             npm publish --registry https://pillarproject.jfrog.io/pillarproject/api/npm/npm/
-            chmod +x .circleci/announceRelease.sh && .circleci/announceRelease.sh "BCX-PUBSUB QA" "$(node -e "console.log(require('./package.json').name)"):$(node -e "console.log($CIRCLE_BUILD_NUM)")"
       - run:
           name: Push txt file to S3 bucket
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           name: Publish Package to Artifactory
           command: |
             npm publish --registry https://pillarproject.jfrog.io/pillarproject/api/npm/npm/
-            chmod +x .circleci/announceRelease.sh && .circleci/announceRelease.sh "BCX-PUBSUB" "$(node -e "console.log(require('./package.json').name)"):$(node -e "console.log($CIRCLE_BUILD_NUM)")"
+            chmod +x .circleci/announceRelease.sh && .circleci/announceRelease.sh "BCX-PUBSUB QA" "$(node -e "console.log(require('./package.json').name)"):$(node -e "console.log($CIRCLE_BUILD_NUM)")"
       - run:
           name: Push txt file to S3 bucket
           command: |


### PR DESCRIPTION
Removing the announcement for QA package since it is not needed as the text file is automatically uploaded in the QA release bucket, no need of manual job.

This way, we will avoid possible versions confusions for the production job.